### PR TITLE
Honour SYSROOT for GNU Classpath install dir

### DIFF
--- a/src/classlib/gnuclasspath/lib/Makefile.am
+++ b/src/classlib/gnuclasspath/lib/Makefile.am
@@ -19,7 +19,7 @@
 ## Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 ##
 
-CP_LIB_DIR = ${with_classpath_install_dir}/share/classpath
+CP_LIB_DIR = $(SYSROOT)${with_classpath_install_dir}/share/classpath
 GLIBJ_ZIP  = ${CP_LIB_DIR}/glibj.zip
 
 SUBDIRS = jamvm java gnu sun


### PR DESCRIPTION
JamVM needs to know the GNU Classpath installation directory so that it can find Classpath class files and shared libraries.

This directory is used at both runtime and build time. However, when cross compiling, these directories typically differ; the build-time directory should honour $(SYSROOT) if set.