### PR TITLE
configure: Don't require librt for clock_gettime

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -264,6 +264,7 @@ AC_CHECK_LIB(thr,pthread_self,,[
 ])
 
 AC_CHECK_LIB(rt,clock_gettime,,)
+AC_CHECK_FUNCS([clock_gettime])
 
 AC_CHECK_LIB(m,fmod,,AC_MSG_ERROR(libm is missing))
 
@@ -437,4 +438,3 @@ AC_CONFIG_FILES(
     src/classlib/gnuclasspath/lib/gnu/classpath/Makefile)
 
 AC_OUTPUT
-

--- a/src/classlib/openjdk/jvm.c
+++ b/src/classlib/openjdk/jvm.c
@@ -59,7 +59,7 @@
 
 /* We use the monotonic clock if it is available.  As the clock_id may be
    present but not actually supported, we check it on startup */
-#if defined(HAVE_LIBRT) && defined(CLOCK_MONOTONIC)
+#if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_MONOTONIC)
 static int have_monotonic_clock;
 #endif
 
@@ -72,7 +72,7 @@ static int constant_pool_oop_offset;
 int initialiseJVMInterface() {
     Class *pae_class;
 
-#if defined(HAVE_LIBRT) && defined(CLOCK_MONOTONIC)
+#if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_MONOTONIC)
     struct timespec ts;
     have_monotonic_clock = (clock_gettime(CLOCK_MONOTONIC, &ts) != -1);
 #endif
@@ -172,7 +172,7 @@ jlong JVM_CurrentTimeMillis(JNIEnv *env, jclass ignored) {
 jlong JVM_NanoTime(JNIEnv *env, jclass ignored) {
     TRACE("JVM_NanoTime(env=%p, ignored=%p)", env, ignored);
 
-#if defined(HAVE_LIBRT) && defined(CLOCK_MONOTONIC)
+#if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_MONOTONIC)
     if(have_monotonic_clock) {
         struct timespec ts;
 


### PR DESCRIPTION
Recent versions of libc (for example glibc >= 2.17) no longer need -lrt for clock_gettime. Check explicitly for availability of clock_gettime in configure (still links librt if needed), and use HAVE_CLOCK_GETTIME instead of HAVE_LIBRT in source code.