### PR TITLE
Fix missing break in nativeExtraArg for linux/aarch64

### DIFF
--- a/src/os/linux/aarch64/dll_md.c
+++ b/src/os/linux/aarch64/dll_md.c
@@ -38,6 +38,7 @@ int nativeExtraArg(MethodBlock *mb) {
                 stack_args += 8;
             else
                 fp_args--;
+            break;
 
         default:
             if(int_args == 0)


### PR DESCRIPTION
The switch statement for 'F'/'D' (float/double) cases was missing a break, causing fall-through to the default case. This incorrectly counted each float/double against both the FP and integer register budgets, potentially over-allocating stack space.