### PR TITLE
Fix callNative.S clang error for linux/aarch64

### DIFF
--- a/src/os/linux/aarch64/callNative.S
+++ b/src/os/linux/aarch64/callNative.S
@@ -64,7 +64,7 @@ callJNIMethod:
         mov     x29, sp
         stp     x19, x20, [x29, #16]
 
-        sub     sp, sp, w3              /* allocate room for stacked args */
+        sub     sp, sp, w3, uxtw        /* allocate room for stacked args */
         mov     x14, sp
 
         mov     x20, x4                 /* preserve ostack */


### PR DESCRIPTION
The instruction 'sub sp, sp, w3' is invalid because sp is 64-bit but w3 is 32-bit. GCC/GAS accepts this (and implicitly adds the uxtw extend specifier), but clang rejects it:

  error: too few operands for instruction
          sub sp, sp, w3
          ^~~~~~~~~~~~~~

Fix this by making the zero-extend explicit, which works under both toolchains.