### PR TITLE
Work around clang hang compiling interp.c with -O1 and higher

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -254,6 +254,26 @@ dnl Checks for programs.
 AC_PROG_CC
 AM_PROG_AS
 
+dnl Check if we're using clang - needed for workarounds
+AC_MSG_CHECKING([whether compiler is clang])
+AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM([], [[
+        #ifndef __clang__
+            #error not clang
+        #endif
+    ]])],
+    [using_clang=yes],
+    [using_clang=no])
+AC_MSG_RESULT([$using_clang])
+
+dnl Clang's TailDuplication pass has exponential time complexity with the
+dnl computed goto dispatch pattern used in the interpreter.  Disable tail
+dnl duplication (for interp.c only) to prevent the hang while keeping all
+dnl other LLVM optimizations intact.
+if test "$using_clang" = yes; then
+    interp_cflags="$interp_cflags -mllvm -tail-dup-limit=0"
+fi
+
 AC_CHECK_PROGS(JAVAC, ecj jikes "gcj -C" javac)
 
 dnl Checks for libraries.


### PR DESCRIPTION
Clang's LLVM backend hangs indefinitely when compiling src/interp/engine/interp.c with optimization level -O1 or higher. The hang is caused by LLVM's TailDuplication pass encountering exponential time complexity with the computed goto dispatch pattern used in the interpreter. The problem can be reproduced on Linux and macOS, and the actual cause was confirmed via profiling.

Work around by adding -mllvm -tail-dup-limit=0 to the interp CFLAGS when compiling with clang. This disables the problematic pass (for interp.c only) while keeping all other LLVM optimizations intact.