### PR TITLE
Fix inline assembly for clang on darwin/aarch64

### DIFF
--- a/src/arch/aarch64.h
+++ b/src/arch/aarch64.h
@@ -38,13 +38,13 @@
 ({                                                              \
     int result, read_val;                                       \
     __asm__ __volatile__ ("                                     \
-        1:      ldaxr %2, %1;                                   \
-                cmp %2, %3;                                     \
-                b.ne 2f;                                        \
-                stlxr %w0, %4, %1;                              \
-                cmp %w0, wzr;                                   \
-                b.ne 1b;                                        \
-        2:      cset %w0, eq;"                                  \
+        1:      ldaxr %2, %1\n                                  \
+                cmp %2, %3\n                                    \
+                b.ne 2f\n                                       \
+                stlxr %w0, %4, %1\n                             \
+                cmp %w0, wzr\n                                  \
+                b.ne 1b\n                                       \
+        2:      cset %w0, eq"                                   \
     : "=&r" (result), "+Q" (*addr), "=&r" (read_val)            \
     : "r" (old_val), "r" (new_val)                              \
     : "cc");                                                    \
@@ -55,13 +55,13 @@
 ({                                                              \
     int result, read_val;                                       \
     __asm__ __volatile__ ("                                     \
-        1:      ldaxr %w2, %1;                                  \
-                cmp %w2, %w3;                                   \
-                b.ne 2f;                                        \
-                stlxr %w0, %w4, %1;                             \
-                cmp %w0, wzr;                                   \
-                b.ne 1b;                                        \
-        2:      cset %w0, eq;"                                  \
+        1:      ldaxr %w2, %1\n                                 \
+                cmp %w2, %w3\n                                  \
+                b.ne 2f\n                                       \
+                stlxr %w0, %w4, %1\n                            \
+                cmp %w0, wzr\n                                  \
+                b.ne 1b\n                                       \
+        2:      cset %w0, eq"                                   \
     : "=&r" (result), "+Q" (*addr), "=&r" (read_val)            \
     : "r" (old_val), "r" (new_val)                              \
     : "cc");                                                    \
@@ -75,7 +75,7 @@
 ({                                                              \
     uintptr_t result;                                           \
     __asm__ __volatile__ ("                                     \
-                ldar %0, %1;"                                   \
+                ldar %0, %1"                                   \
     : "=r" (result)                                             \
     : "Q" (*addr)                                               \
     : "cc");                                                    \
@@ -85,7 +85,7 @@
 #define LOCKWORD_WRITE(addr, value)                             \
 ({                                                              \
     __asm__ __volatile__ ("                                     \
-                stlr %1, %0;"                                   \
+                stlr %1, %0"                                   \
     : "=Q" (*addr)                                              \
     : "r" (value)                                               \
     : "cc");                                                    \
@@ -112,7 +112,7 @@
         i += aarch64_instruction_cache_line_len)                \
         __asm__ ("ic ivau, %0" :: "r" (i));                     \
                                                                 \
-    __asm__ ("dsb ish; isb");                                   \
+    __asm__ ("dsb ish\n isb");                                   \
 }
 
 #define GEN_REL_JMP(target_addr, patch_addr, patch_size)        \

--- a/src/interp/engine/interp2.c
+++ b/src/interp/engine/interp2.c
@@ -23,7 +23,7 @@
 
 #ifdef INLINING
 #define executeJava() executeJava2()
-#define PAD __asm__(".space 4; .space 4; .space 4; .space 4");
+#define PAD __asm__(".space 4\n .space 4\n .space 4\n .space 4");
 
 #include "interp.c"
 #endif


### PR DESCRIPTION
LLVM's integrated assembler treats semicolons as comment delimiters on darwin/aarch64, causing inline assembly with multiple instructions to silently drop all instructions after the first semicolon.

This makes the VM fail during initialization: when trying to link java/lang/Object, it calls objectLock() to acquire a lock. This function uses LOCKWORD_COMPARE_AND_SWAP which expands to the broken COMPARE_AND_SWAP_64 macro.

Fix by replacing semicolons with newlines (\n) in all affected macros:

- aarch64.h: COMPARE_AND_SWAP_32/64, LOCKWORD_READ/WRITE (for consistency only -- no real impact), and FLUSH_CACHE.
- interp2.c: architecture-independent PAD macro.

The change is safe since newlines are the universal statement separator across all targets for both GAS and LLVM's integrated assembler.