### PR TITLE
Fix operand types in aarch64 inline asm

### DIFF
--- a/src/arch/aarch64.h
+++ b/src/arch/aarch64.h
@@ -36,7 +36,8 @@
 
 #define COMPARE_AND_SWAP_64(addr, old_val, new_val)             \
 ({                                                              \
-    int result, read_val;                                       \
+    int result;                                                 \
+    uintptr_t read_val;                                         \
     __asm__ __volatile__ ("                                     \
         1:      ldaxr %2, %1\n                                  \
                 cmp %2, %3\n                                    \
@@ -46,7 +47,7 @@
                 b.ne 1b\n                                       \
         2:      cset %w0, eq"                                   \
     : "=&r" (result), "+Q" (*addr), "=&r" (read_val)            \
-    : "r" (old_val), "r" (new_val)                              \
+    : "r" ((uintptr_t)(old_val)), "r" ((uintptr_t)(new_val))    \
     : "cc");                                                    \
     result;                                                     \
 })
@@ -87,7 +88,7 @@
     __asm__ __volatile__ ("                                     \
                 stlr %1, %0"                                   \
     : "=Q" (*addr)                                              \
-    : "r" (value)                                               \
+    : "r" ((uintptr_t)(value))                                  \
     : "cc");                                                    \
 })
 

--- a/src/os/linux/aarch64/init.c
+++ b/src/os/linux/aarch64/init.c
@@ -36,7 +36,7 @@ unsigned char aarch64_instruction_cache_line_len;
 uintptr_t aarch64_instruction_cache_line_mask;
 
 void initialisePlatform() {
-    unsigned int cache_type;
+    unsigned long cache_type;
 
     /* Extract information from the cache-type register, which describes aspects
        of the host's cache configuration */


### PR DESCRIPTION
In some cases, aarch64 inline asm operands used 32-bit types where 64-bit registers were required. While both clang and GCC generate correct code regardless, the operand types should match the register sizes for correctness and to silence clang -Wasm-operand-widths warnings.

- COMPARE_AND_SWAP_64: change read_val from int to uintptr_t, cast old_val/new_val to uintptr_t (64-bit registers)
- LOCKWORD_WRITE: cast value to uintptr_t (64-bit register)
- initialisePlatform (linux/aarch64): change cache_type from unsigned int to unsigned long, as mrs always writes a 64-bit register