### PR TITLE
Support newer versions of javac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -277,6 +277,12 @@ fi
 
 AC_CHECK_PROGS(JAVAC, ecj jikes "gcj -C" javac)
 
+case "$JAVAC" in
+    javac) JAVAC_FLAGS="-source 1.6 -target 1.6" ;;
+    *)     JAVAC_FLAGS="" ;;
+esac
+AC_SUBST(JAVAC_FLAGS)
+
 dnl Checks for libraries.
 
 dnl Prefer libthr to libpthread (for FreeBSD)

--- a/src/classlib/gnuclasspath/lib/Makefile.am
+++ b/src/classlib/gnuclasspath/lib/Makefile.am
@@ -50,7 +50,7 @@ inst_classes.zip: classes.zip
 
 classes.zip: $(JAVA_FILES)
 	-mkdir classes
-	$(JAVAC) -bootclasspath ${GLIBJ_ZIP} -d classes $(JAVA_FILES)
+	$(JAVAC) $(JAVAC_FLAGS) -bootclasspath ${GLIBJ_ZIP} -d classes $(JAVA_FILES)
 	cd classes && zip -r ../classes.zip .
 	rm -rf classes
 


### PR DESCRIPTION
JamVM needs a java compiler when building for GNU Classpath, in order to compile the VM support classes (classes.zip). Currently, this breaks on JDK 9 or later, since the javac invocation uses -bootclasspath, which (on JDK 9+) needs explicit -source/-target.

Fix by adding -source 1.6 -target 1.6 to javac options (same as used by GNU Classpath itself).

While we are at this, also drop support for GCJ and Jikes. GCJ was officially discontinued in 2016 (removed from GCC 7). Jikes support was also removed from GNU Classpath long ago.