### PR TITLE
OpenJDK fixes

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -379,6 +379,7 @@ Class *parseClass(char *classname, char *data, int offset, int len,
     }
 
     classblock->class_loader = class_loader;
+    classlibSetClassLoader(class, class_loader);
 
     READ_U2(intf_count = classblock->interfaces_count, ptr, len);
     interfaces = classblock->interfaces =
@@ -813,6 +814,7 @@ Class *createArrayClass(char *classname, Object *class_loader) {
 
     /* The array's classloader is the loader of the element class */
     classblock->class_loader = elem_cb->class_loader;
+    classlibSetClassLoader(class, elem_cb->class_loader);
 
     /* The array's visibility (i.e. public, etc.) is that of the element */
     classblock->access_flags = (elem_cb->access_flags & ~ACC_INTERFACE) |
@@ -1473,6 +1475,9 @@ void linkClass(Class *class) {
        classlibCacheClassLoaderFields(class);
        cb->flags |= CLASS_LOADER;
    }
+
+   if(cb->flags & CLASS_CLASS)
+       classlibCacheClassFields(class);
 
    cb->state = CLASS_LINKED;
 

--- a/src/classlib/gnuclasspath/classlib.h
+++ b/src/classlib/gnuclasspath/classlib.h
@@ -76,6 +76,9 @@ extern void classlibNewLibraryUnloader(Object *class_loader, void *entry);
 #define classlibSkipReflectionLoader(loader) \
     loader
 
+#define classlibCacheClassFields(class) {}
+#define classlibSetClassLoader(class, loader) {}
+
 #define classlibInjectedFieldsCount(classname) 0
 #define classlibFillInInjectedFields(classname, field) {}
 

--- a/src/classlib/openjdk/classlib.h
+++ b/src/classlib/openjdk/classlib.h
@@ -53,6 +53,8 @@ extern void classlibSignalThread(Thread *self);
     /* NOTHING TO DO */ TRUE
 
 extern void classlibCacheClassLoaderFields(Class *loader_class);
+extern void classlibCacheClassFields(Class *class);
+extern void classlibSetClassLoader(Class *class, Object *loader);
 extern HashTable *classlibLoaderTable(Object *class_loader);
 extern HashTable *classlibCreateLoaderTable(Object *class_loader);
 extern Object *classlibBootPackage(PackageEntry *entry);

--- a/src/classlib/openjdk/jvm.c
+++ b/src/classlib/openjdk/jvm.c
@@ -669,6 +669,35 @@ void JVM_SetClassSigners(JNIEnv *env, jclass cls, jobjectArray signers) {
 }
 
 
+/* JVM_GetResourceLookupCacheURLs
+   is part of the
+   JDK-8061651 JDK8u API
+*/
+
+jobjectArray JVM_GetResourceLookupCacheURLs(JNIEnv *env, jobject loader) {
+    return NULL; // tell OpenJDK 8 that the lookup cache API is unavailable
+}
+
+/* JVM_GetResourceLookupCache
+   is unused however it is part of the
+   JDK-8061651 JDK8u API
+*/
+
+jintArray JVM_GetResourceLookupCache(JNIEnv *env, jobject loader, const char *resource_name) {
+    UNIMPLEMENTED("JVM_GetResourceLookupCache");
+    return 0;
+}
+
+/* JVM_KnownToNotExist
+   is unused however it is part of the
+   JDK-8061651 JDK8u API
+*/
+
+jboolean JVM_KnownToNotExist(JNIEnv *env, jobject loader, const char *classname) {
+    UNIMPLEMENTED("JVM_KnownToNotExist");
+    return 0;
+}
+
 /* JVM_GetProtectionDomain */
 
 jobject JVM_GetProtectionDomain(JNIEnv *env, jclass cls) {

--- a/src/symbol.h
+++ b/src/symbol.h
@@ -53,6 +53,7 @@ extern char *symbol_values[];
     action(initCause, "initCause"), \
     action(loadClass, "loadClass"), \
     action(returnType, "returnType"), \
+    action(classLoader, "classLoader"), \
     action(declaringClass, "declaringClass"), \
     action(parameterTypes, "parameterTypes"), \
     action(printStackTrace, "printStackTrace"), \


### PR DESCRIPTION
[JDK-8061651](https://bugs.openjdk.org/browse/JDK-8061651) added a class/resource lookup cache API that introduced three new JVM entry points: `JVM_GetResourceLookupCacheURLs`, `JVM_GetResourceLookupCache`, and `JVM_KnownToNotExist`. Since libjava.so references these symbols, the dynamic linker fails to resolve them if they are missing from libjvm.so, causing any Java application to crash at startup with an undefined symbol error. The first commit fixes this by adding minimal stub implementations to tell the JDK libraries that the cache is unavailable. 

The second commit fixes `Class.getClassLoader()` after the changes introduced in [JDK-6642881](https://bugs.openjdk.org/browse/JDK-6642881).
