### PR TITLE
Fix signature of scandir filter callback for Darwin

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -2190,7 +2190,7 @@ char *getClassPath() {
     return classpath;
 }
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 int filter(const struct dirent *entry) {
 #else
 int filter(struct dirent *entry) {


### PR DESCRIPTION
According to POSIX 2008, the scandir filter callback takes a const dirent pointer. The existing code used the const-qualified signature for Linux only, but Darwin requires it too. This caused a warning (-Wincompatible-function-pointer-types) which recent versions of clang treat as a hard error:

  error: incompatible function pointer types passing
         'int (*)(struct dirent *)' to parameter of type
         'int (*)(const struct dirent *)'

Fix by using the correct POSIX signature on Darwin as well. The non-const fallback is kept for older non-conforming systems.